### PR TITLE
Adds a JSON marshalling handler for loader types:

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -112,6 +112,10 @@ func (b *Loader[T]) UnmarshalJSON(raw []byte) error {
 	return json.Unmarshal(raw, b.Builder)
 }
 
+func (l Loader[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.Builder)
+}
+
 func (l Loader[T]) Configure() (T, error) {
 	var t T
 	if l.Builder == nil {


### PR DESCRIPTION
- When martialling, omit the "Builder:" layer of json and just marshal the loaded type directly.