### PR TITLE
await: directly check for context.Canceled errors:

### DIFF
--- a/await/await.go
+++ b/await/await.go
@@ -163,7 +163,7 @@ loop:
 	cancel(fmt.Errorf("await: %w", err))
 
 	err = waitOrTimeout(r.stopTimeout, &waitCount, err)
-	if errors.Is(err, context.Canceled) {
+	if err == context.Canceled {
 		return nil
 	}
 


### PR DESCRIPTION
- Use a direct equality check to tell if a suboutine was ended due to a context.Canceled error.  The old check using errors.Is() would falsely catch library errors that themselves wrap context.Canceled.  In those cases, we should propogate the error instead of exiting cleanly.