### PR TITLE
cli: allow global flags before command names

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -83,6 +83,22 @@ func (s *ServeCmd) Run(ctx context.Context, args []string) error {
 }
 ```
 
+Global flags can appear anywhere in the argument list — before, between, or
+after command names:
+
+```bash
+myapp --verbose serve --addr :9090       # before command
+myapp serve --verbose --addr :9090       # after command (also works)
+myapp admin --verbose migrate            # between command and subcommand
+myapp --config prod.json admin migrate   # before nested subcommand
+```
+
+**Collisions:** If a handler defines a flag with the same name as a global
+flag, the framework panics with a clear error at startup. Rename one of them
+to resolve the collision. Two commands on separate branches may independently
+use the same flag name without conflict — each command builds its own flag
+set at execution time.
+
 ### Configure-Validate-Run Lifecycle
 
 Globals and handlers can implement optional lifecycle interfaces:

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -190,7 +190,10 @@ func WithConfigFlag(flagName string) AppOption {
 // the collision. Two commands on separate branches may independently use
 // the same flag name without conflict.
 func WithGlobals(ptr any) AppOption {
-	return func(a *App) { a.globals = ptr }
+	return func(a *App) {
+		a.globals = ptr
+		a.globalFlags = scanGlobalFlags(ptr)
+	}
 }
 
 // WithDefaultConfig registers a default configuration that can be printed
@@ -220,6 +223,7 @@ type App struct {
 	version          string
 	configFlag       string
 	globals          any // pointer to globals struct, if set
+	globalFlags      map[string]globalFlagInfo
 	defaultConfig    []byte
 	defaultConfigCmd string
 	middlewares      []Middleware
@@ -296,69 +300,21 @@ func (a *App) run(ctx context.Context, args []string) (int, error) {
 		return 0, nil
 	}
 
-	// Strip recognized global flags for routing so that flags like
-	// --profile before a command name don't break command lookup.
-	routingArgs := args
-	if a.globals != nil {
-		routingArgs = stripGlobalFlags(args, a.globals)
-	}
-
-	node, _, path := routeArgsWithPath(a.children, routingArgs, "")
+	node, rest, path := routeArgsWithPath(a.children, args, "", a.globalFlags)
 	if node == nil {
-		// Unknown command
-		fmt.Fprintf(a.output, "unknown command %q\n\n", routingArgs[0])
+		first := args[0]
+		if i := skipGlobalFlags(args, a.globalFlags); i < len(args) {
+			first = args[i]
+		}
+		fmt.Fprintf(a.output, "unknown command %q\n\n", first)
 		printAppHelp(a.output, a.name, a.desc, a.children, a.version, a.defconCmd())
 		return 1, nil
 	}
 
-	// Remove the routed command path segments from the original
-	// (unstripped) args so global flags pass through to executeCommand.
-	execArgs := removeRoutedSegments(args, path)
-
-	return a.executeNode(ctx, node, execArgs, path)
+	return a.executeNode(ctx, node, rest, path)
 }
 
-func routeArgsWithPath(children []Node, args []string, prefix string) (Node, []string, string) {
-	if len(args) == 0 {
-		return nil, args, prefix
-	}
-
-	name := args[0]
-	// Don't treat flags as command names
-	if strings.HasPrefix(name, "-") {
-		return nil, args, prefix
-	}
-
-	for _, child := range children {
-		if child.nodeName() == name {
-			fullPath := name
-			if prefix != "" {
-				fullPath = prefix + " " + name
-			}
-			rest := args[1:]
-
-			// If this node has children and the next arg matches one, recurse
-			var subChildren []Node
-			switch n := child.(type) {
-			case *commandNode:
-				subChildren = n.children
-			case *groupNode:
-				subChildren = n.children
-			}
-
-			if len(subChildren) > 0 && len(rest) > 0 && !strings.HasPrefix(rest[0], "-") {
-				if sub, subRest, subPath := routeArgsWithPath(subChildren, rest, fullPath); sub != nil {
-					return sub, subRest, subPath
-				}
-			}
-
-			return child, rest, fullPath
-		}
-	}
-	return nil, args, prefix
-}
-
-// globalFlagInfo describes a known global flag for pre-routing stripping.
+// globalFlagInfo describes a known global flag for routing.
 type globalFlagInfo struct {
 	isBool bool
 }
@@ -397,65 +353,73 @@ func scanGlobalFlags(globals any) map[string]globalFlagInfo {
 	return m
 }
 
-// stripGlobalFlags removes recognized global flags (and their values) from
-// args so that command routing sees only command names and non-global args.
-func stripGlobalFlags(args []string, globals any) []string {
-	gflags := scanGlobalFlags(globals)
-	if len(gflags) == 0 {
-		return args
-	}
-
-	out := make([]string, 0, len(args))
-	for i := 0; i < len(args); i++ {
+// skipGlobalFlags returns the index of the first arg that is not a recognized
+// global flag (or its value). Stops at "--".
+func skipGlobalFlags(args []string, gflags map[string]globalFlagInfo) int {
+	i := 0
+	for i < len(args) {
 		arg := args[i]
-
 		if arg == "--" {
-			out = append(out, args[i:]...)
 			break
 		}
-
-		// Check --flag=value or -f=value
 		if eqIdx := strings.IndexByte(arg, '='); eqIdx > 0 && strings.HasPrefix(arg, "-") {
-			name := arg[:eqIdx]
-			if _, ok := gflags[name]; ok {
+			if _, ok := gflags[arg[:eqIdx]]; ok {
+				i++
 				continue
 			}
-			out = append(out, arg)
-			continue
+			break
 		}
-
 		info, ok := gflags[arg]
 		if !ok {
-			out = append(out, arg)
-			continue
+			break
 		}
-
-		// It's a known global flag — skip it
-		if info.isBool {
-			continue
-		}
-		// Non-bool: also skip the next arg (the value)
-		if i+1 < len(args) {
+		i++
+		if !info.isBool && i < len(args) {
 			i++
 		}
 	}
-	return out
+	return i
 }
 
-// removeRoutedSegments removes the command path segments from the original
-// args, preserving all flags and other arguments.
-func removeRoutedSegments(args []string, path string) []string {
-	segments := strings.Fields(path)
-	out := make([]string, 0, len(args))
-	seg := 0
-	for _, arg := range args {
-		if seg < len(segments) && arg == segments[seg] {
-			seg++
-			continue
-		}
-		out = append(out, arg)
+func routeArgsWithPath(children []Node, args []string, prefix string, gflags map[string]globalFlagInfo) (Node, []string, string) {
+	i := skipGlobalFlags(args, gflags)
+	if i >= len(args) {
+		return nil, args, prefix
 	}
-	return out
+
+	name := args[i]
+	if strings.HasPrefix(name, "-") {
+		return nil, args, prefix
+	}
+
+	for _, child := range children {
+		if child.nodeName() == name {
+			fullPath := name
+			if prefix != "" {
+				fullPath = prefix + " " + name
+			}
+			rest := make([]string, 0, len(args)-1)
+			rest = append(rest, args[:i]...)
+			rest = append(rest, args[i+1:]...)
+
+			var subChildren []Node
+			switch n := child.(type) {
+			case *commandNode:
+				subChildren = n.children
+			case *groupNode:
+				subChildren = n.children
+			}
+
+			if len(subChildren) > 0 {
+				if sub, subRest, subPath := routeArgsWithPath(subChildren, rest, fullPath, gflags); sub != nil {
+					return sub, subRest, subPath
+				}
+			}
+
+			return child, rest, fullPath
+		}
+	}
+	return nil, args, prefix
 }
 
 func (a *App) executeNode(ctx context.Context, node Node, args []string, path string) (int, error) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -176,6 +176,19 @@ func WithConfigFlag(flagName string) AppOption {
 // WithGlobals registers a struct pointer whose cli-tagged fields become
 // flags available on every command. The pointer is stored in context and
 // can be retrieved with GlobalsFromContext.
+//
+// Global flags may appear anywhere in the argument list — before, between,
+// or after command and subcommand names. For example, all of these are
+// equivalent:
+//
+//	myapp --profile staging auth login
+//	myapp auth --profile staging login
+//	myapp auth login --profile staging
+//
+// If a handler struct defines a flag with the same name as a global flag,
+// the framework panics with a clear error. Rename one of them to resolve
+// the collision. Two commands on separate branches may independently use
+// the same flag name without conflict.
 func WithGlobals(ptr any) AppOption {
 	return func(a *App) { a.globals = ptr }
 }
@@ -283,15 +296,26 @@ func (a *App) run(ctx context.Context, args []string) (int, error) {
 		return 0, nil
 	}
 
-	node, rest, path := routeArgsWithPath(a.children, args, "")
+	// Strip recognized global flags for routing so that flags like
+	// --profile before a command name don't break command lookup.
+	routingArgs := args
+	if a.globals != nil {
+		routingArgs = stripGlobalFlags(args, a.globals)
+	}
+
+	node, _, path := routeArgsWithPath(a.children, routingArgs, "")
 	if node == nil {
 		// Unknown command
-		fmt.Fprintf(a.output, "unknown command %q\n\n", args[0])
+		fmt.Fprintf(a.output, "unknown command %q\n\n", routingArgs[0])
 		printAppHelp(a.output, a.name, a.desc, a.children, a.version, a.defconCmd())
 		return 1, nil
 	}
 
-	return a.executeNode(ctx, node, rest, path)
+	// Remove the routed command path segments from the original
+	// (unstripped) args so global flags pass through to executeCommand.
+	execArgs := removeRoutedSegments(args, path)
+
+	return a.executeNode(ctx, node, execArgs, path)
 }
 
 func routeArgsWithPath(children []Node, args []string, prefix string) (Node, []string, string) {
@@ -332,6 +356,106 @@ func routeArgsWithPath(children []Node, args []string, prefix string) (Node, []s
 		}
 	}
 	return nil, args, prefix
+}
+
+// globalFlagInfo describes a known global flag for pre-routing stripping.
+type globalFlagInfo struct {
+	isBool bool
+}
+
+// scanGlobalFlags reflects on the globals struct to build a map of flag names
+// (both long and short forms) to their type info.
+func scanGlobalFlags(globals any) map[string]globalFlagInfo {
+	rv := reflect.ValueOf(globals)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil
+	}
+
+	fields, err := scanFields(rv.Type())
+	if err != nil {
+		return nil
+	}
+
+	m := make(map[string]globalFlagInfo)
+	for _, fi := range fields {
+		if fi.flagLong == "" {
+			continue
+		}
+		ft := fi.fieldType
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		info := globalFlagInfo{isBool: ft.Kind() == reflect.Bool}
+		m["--"+fi.flagLong] = info
+		if fi.flagShort != "" {
+			m["-"+fi.flagShort] = info
+		}
+	}
+	return m
+}
+
+// stripGlobalFlags removes recognized global flags (and their values) from
+// args so that command routing sees only command names and non-global args.
+func stripGlobalFlags(args []string, globals any) []string {
+	gflags := scanGlobalFlags(globals)
+	if len(gflags) == 0 {
+		return args
+	}
+
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if arg == "--" {
+			out = append(out, args[i:]...)
+			break
+		}
+
+		// Check --flag=value or -f=value
+		if eqIdx := strings.IndexByte(arg, '='); eqIdx > 0 && strings.HasPrefix(arg, "-") {
+			name := arg[:eqIdx]
+			if _, ok := gflags[name]; ok {
+				continue
+			}
+			out = append(out, arg)
+			continue
+		}
+
+		info, ok := gflags[arg]
+		if !ok {
+			out = append(out, arg)
+			continue
+		}
+
+		// It's a known global flag — skip it
+		if info.isBool {
+			continue
+		}
+		// Non-bool: also skip the next arg (the value)
+		if i+1 < len(args) {
+			i++
+		}
+	}
+	return out
+}
+
+// removeRoutedSegments removes the command path segments from the original
+// args, preserving all flags and other arguments.
+func removeRoutedSegments(args []string, path string) []string {
+	segments := strings.Fields(path)
+	out := make([]string, 0, len(args))
+	seg := 0
+	for _, arg := range args {
+		if seg < len(segments) && arg == segments[seg] {
+			seg++
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
 }
 
 func (a *App) executeNode(ctx context.Context, node Node, args []string, path string) (int, error) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -381,7 +381,12 @@ func skipGlobalFlags(args []string, gflags map[string]globalFlagInfo) int {
 	return i
 }
 
-func routeArgsWithPath(children []Node, args []string, prefix string, gflags map[string]globalFlagInfo) (Node, []string, string) {
+func routeArgsWithPath(
+	children []Node,
+	args []string,
+	prefix string,
+	gflags map[string]globalFlagInfo,
+) (Node, []string, string) {
 	i := skipGlobalFlags(args, gflags)
 	if i >= len(args) {
 		return nil, args, prefix

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -553,6 +553,12 @@ type configHandler struct {
 
 func (c *configHandler) Run(_ context.Context, _ []string) error { return nil }
 
+type dbConfigOnlyCmd struct {
+	DB dbSection `config:"database"`
+}
+
+func (d *dbConfigOnlyCmd) Run(_ context.Context, _ []string) error { return nil }
+
 func TestConfig_BasicLoad(t *testing.T) {
 	handler := &configHandler{}
 	f := writeConfigFile(t, `{
@@ -754,32 +760,24 @@ func TestGlobals_FromContext(t *testing.T) {
 }
 
 func TestGlobals_ConfigFlagOnGlobals(t *testing.T) {
-	type serveWithConfig struct {
-		DB dbSection `config:"database"`
-	}
-	handler := &struct {
-		serveWithConfig
-	}{}
-	handler.serveWithConfig = serveWithConfig{}
+	// Handler has config tags but no --config flag — the flag lives on globals.
+	handler := &dbConfigOnlyCmd{}
 
-	// Use a handler that has config tags but no config flag —
-	// the config flag is on globals.
 	g := &testGlobals{}
 	f := writeConfigFile(t, `{"database": {"host": "global-host", "port": 3306}}`)
 
-	configCmd := &configHandler{DB: dbSection{}}
 	var buf bytes.Buffer
 	app := cli.New("app", "test",
 		cli.WithOutput(&buf),
 		cli.WithGlobals(g),
 		cli.WithConfigFlag("config"),
 	)
-	app.AddCommand(cli.Command("run", "run", configCmd))
+	app.AddCommand(cli.Command("run", "run", handler))
 
 	code := app.Run(context.Background(), []string{"run", "--config", f})
 	assert.Equal(t, 0, code)
-	assert.Equal(t, "global-host", configCmd.DB.Host)
-	assert.Equal(t, 3306, configCmd.DB.Port)
+	assert.Equal(t, "global-host", handler.DB.Host)
+	assert.Equal(t, 3306, handler.DB.Port)
 }
 
 // --- CVR lifecycle on globals ---
@@ -1349,4 +1347,165 @@ func TestFlagParsing_ShortFlagMissingValue(t *testing.T) {
 	code := app.Run(context.Background(), []string{"echo", "-m"})
 	assert.Equal(t, 1, code)
 	assert.Contains(t, buf.String(), "requires a value")
+}
+
+// --- Global flags before/between/after command routing ---
+
+type profileGlobals struct {
+	Profile string `cli:"profile,p" usage:"profile name"`
+	Verbose bool   `cli:"verbose,v" usage:"verbose"`
+}
+
+type authLoginCmd struct {
+	Token   string `cli:"token,t" usage:"auth token"`
+	globals *profileGlobals
+}
+
+func (a *authLoginCmd) Run(ctx context.Context, _ []string) error {
+	a.globals = cli.GlobalsFromContext[profileGlobals](ctx)
+	return nil
+}
+
+func TestGlobals_BeforeCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantProfile string
+		wantVerbose bool
+		wantToken   string
+	}{
+		{
+			name:        "global flag before command",
+			args:        []string{"--profile", "staging", "auth", "login"},
+			wantProfile: "staging",
+		},
+		{
+			name:        "global flag between command and subcommand",
+			args:        []string{"auth", "--profile", "staging", "login"},
+			wantProfile: "staging",
+		},
+		{
+			name:        "global flag after subcommand",
+			args:        []string{"auth", "login", "--profile", "staging"},
+			wantProfile: "staging",
+		},
+		{
+			name:        "global flag with = syntax before command",
+			args:        []string{"--profile=staging", "auth", "login"},
+			wantProfile: "staging",
+		},
+		{
+			name:        "short global flag before command",
+			args:        []string{"-p", "staging", "auth", "login"},
+			wantProfile: "staging",
+		},
+		{
+			name:        "boolean global flag before command",
+			args:        []string{"--verbose", "auth", "login"},
+			wantVerbose: true,
+		},
+		{
+			name:        "multiple global flags before command",
+			args:        []string{"--profile", "staging", "--verbose", "auth", "login"},
+			wantProfile: "staging",
+			wantVerbose: true,
+		},
+		{
+			name:        "global and command flags mixed",
+			args:        []string{"--profile", "staging", "auth", "login", "--token", "abc"},
+			wantProfile: "staging",
+			wantToken:   "abc",
+		},
+		{
+			name:        "all flags after subcommand",
+			args:        []string{"auth", "login", "--profile", "staging", "--token", "abc", "--verbose"},
+			wantProfile: "staging",
+			wantToken:   "abc",
+			wantVerbose: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &profileGlobals{}
+			cmd := &authLoginCmd{}
+			var buf bytes.Buffer
+			app := cli.New("app", "test", cli.WithOutput(&buf), cli.WithGlobals(g))
+			app.AddCommand(cli.Group("auth", "auth commands",
+				cli.Command("login", "log in", cmd),
+			))
+
+			code := app.Run(context.Background(), tt.args)
+			assert.Equal(t, 0, code, "output: %s", buf.String())
+			assert.Equal(t, tt.wantProfile, g.Profile)
+			assert.Equal(t, tt.wantVerbose, g.Verbose)
+			assert.Equal(t, tt.wantToken, cmd.Token)
+		})
+	}
+}
+
+func TestGlobals_DoubleDashStopsStripping(t *testing.T) {
+	var capturedArgs []string
+	handler := &captureArgsCmd{inner: func(args []string) { capturedArgs = args }}
+	g := &profileGlobals{}
+
+	var buf bytes.Buffer
+	app := cli.New("app", "test", cli.WithOutput(&buf), cli.WithGlobals(g))
+	app.AddCommand(cli.Command("run", "run", handler))
+
+	code := app.Run(context.Background(), []string{"run", "--", "--profile", "staging"})
+	assert.Equal(t, 0, code, "output: %s", buf.String())
+	assert.Equal(t, "", g.Profile)
+	assert.Equal(t, []string{"--profile", "staging"}, capturedArgs)
+}
+
+func TestGlobals_CollisionPanics(t *testing.T) {
+	type collisionGlobals struct {
+		Message string `cli:"message,m" usage:"global message"`
+	}
+
+	g := &collisionGlobals{}
+	cmd := &echoCmd{} // also has --message
+	var buf bytes.Buffer
+	app := cli.New("app", "test", cli.WithOutput(&buf), cli.WithGlobals(g))
+	app.AddCommand(cli.Command("echo", "echo", cmd))
+
+	// The panic is caught by App.Run's recover — verify it surfaces as exit code 1.
+	code := app.Run(context.Background(), []string{"echo"})
+	assert.Equal(t, 1, code)
+}
+
+func TestGlobals_SameFlagDifferentBranches(t *testing.T) {
+	type branchGlobals struct {
+		Verbose bool `cli:"verbose,v" usage:"verbose"`
+	}
+
+	g := &branchGlobals{}
+	cmd1 := &echoCmd{}
+	cmd2 := &echoCmd{}
+	var buf bytes.Buffer
+	app := cli.New("app", "test", cli.WithOutput(&buf), cli.WithGlobals(g))
+	app.AddCommand(
+		cli.Command("auth", "auth", cmd1),
+		cli.Command("api", "api", cmd2),
+	)
+
+	code := app.Run(context.Background(), []string{"auth", "--message", "abc"})
+	assert.Equal(t, 0, code, "output: %s", buf.String())
+	assert.Equal(t, "abc", cmd1.Message)
+
+	code = app.Run(context.Background(), []string{"api", "--message", "xyz"})
+	assert.Equal(t, 0, code, "output: %s", buf.String())
+	assert.Equal(t, "xyz", cmd2.Message)
+}
+
+func TestGlobals_NoGlobalsStillWorks(t *testing.T) {
+	cmd := &echoCmd{}
+	var buf bytes.Buffer
+	app := cli.New("app", "test", cli.WithOutput(&buf))
+	app.AddCommand(cli.Command("echo", "echo", cmd))
+
+	code := app.Run(context.Background(), []string{"echo", "--message", "hi"})
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hi", cmd.Message)
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1381,23 +1381,23 @@ func TestGlobals_BeforeCommand(t *testing.T) {
 		},
 		{
 			name:        "global flag between command and subcommand",
-			args:        []string{"auth", "--profile", "staging", "login"},
-			wantProfile: "staging",
+			args:        []string{"auth", "--profile", "production", "login"},
+			wantProfile: "production",
 		},
 		{
 			name:        "global flag after subcommand",
-			args:        []string{"auth", "login", "--profile", "staging"},
-			wantProfile: "staging",
+			args:        []string{"auth", "login", "--profile", "dev"},
+			wantProfile: "dev",
 		},
 		{
 			name:        "global flag with = syntax before command",
-			args:        []string{"--profile=staging", "auth", "login"},
-			wantProfile: "staging",
+			args:        []string{"--profile=eu-west", "auth", "login"},
+			wantProfile: "eu-west",
 		},
 		{
 			name:        "short global flag before command",
-			args:        []string{"-p", "staging", "auth", "login"},
-			wantProfile: "staging",
+			args:        []string{"-p", "us-east", "auth", "login"},
+			wantProfile: "us-east",
 		},
 		{
 			name:        "boolean global flag before command",
@@ -1406,8 +1406,8 @@ func TestGlobals_BeforeCommand(t *testing.T) {
 		},
 		{
 			name:        "multiple global flags before command",
-			args:        []string{"--profile", "staging", "--verbose", "auth", "login"},
-			wantProfile: "staging",
+			args:        []string{"--profile", "ci", "--verbose", "auth", "login"},
+			wantProfile: "ci",
 			wantVerbose: true,
 		},
 		{
@@ -1418,8 +1418,8 @@ func TestGlobals_BeforeCommand(t *testing.T) {
 		},
 		{
 			name:        "all flags after subcommand",
-			args:        []string{"auth", "login", "--profile", "staging", "--token", "abc", "--verbose"},
-			wantProfile: "staging",
+			args:        []string{"auth", "login", "--profile", "local", "--token", "abc", "--verbose"},
+			wantProfile: "local",
 			wantToken:   "abc",
 			wantVerbose: true,
 		},

--- a/cli/reflect.go
+++ b/cli/reflect.go
@@ -128,7 +128,9 @@ func buildFlagSet(handler Runnable) (*FlagSet, []fieldInfo, error) {
 }
 
 // addGlobalsToFlagSet scans a globals struct pointer and adds its cli-tagged
-// fields to the given FlagSet. Returns the scanned fields for default application.
+// fields to the given FlagSet. If a handler defines a flag with the same name
+// as a global flag, addGlobalsToFlagSet panics — rename one of them.
+// Returns the scanned fields for default application.
 func addGlobalsToFlagSet(fs *FlagSet, globals any) ([]fieldInfo, error) {
 	rv := reflect.ValueOf(globals)
 	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
@@ -145,9 +147,8 @@ func addGlobalsToFlagSet(fs *FlagSet, globals any) ([]fieldInfo, error) {
 		if fi.flagLong == "" {
 			continue
 		}
-		// Skip if handler already defines this flag (handler wins).
 		if _, exists := fs.byLong[fi.flagLong]; exists {
-			continue
+			panic(fmt.Sprintf("cli: command flag --%s collides with global flag of the same name", fi.flagLong))
 		}
 
 		fieldVal := fieldByIndex(rv, fi.fieldIndex)


### PR DESCRIPTION
## Summary

- Global flags (`WithGlobals`) can now appear anywhere in the argument list — before, between, or after command/subcommand names (e.g. `myapp --profile staging auth login`)
- If a handler defines a flag with the same name as a global flag, the framework panics with a clear error instead of silently resolving the collision
- Two commands on separate branches can independently use the same flag name without conflict

## Test plan

- [x] Global flag before command: `--profile staging auth login`
- [x] Global flag between command and subcommand: `auth --profile staging login`
- [x] Global flag after subcommand: `auth login --profile staging`
- [x] `=` syntax: `--profile=staging auth login`
- [x] Short flag: `-p staging auth login`
- [x] Boolean global flag: `--verbose auth login`
- [x] Multiple global flags mixed with command flags
- [x] `--` separator stops global stripping
- [x] Collision panics with clear message
- [x] Same flag name on separate branches works independently
- [x] No regression on commands without globals
- [x] Full existing test suite passes