### PR TITLE
cli: use actual binary name in completion scripts

### DIFF
--- a/cli/complete.go
+++ b/cli/complete.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -44,15 +46,19 @@ func (a *App) handleCompletionScript(args []string) int {
 		)
 		return 1
 	}
+	// Use the actual binary name so the completion script matches
+	// whatever name the binary was installed as.
+	binName := filepath.Base(os.Args[0])
+
 	// Completion scripts and __complete output go to stdout, not
 	// a.output (which defaults to stderr). The shell reads stdout.
 	switch args[0] {
 	case "bash":
-		writeBashCompletion(a.stdout, a.name)
+		writeBashCompletion(a.stdout, binName)
 	case "zsh":
-		writeZshCompletion(a.stdout, a.name)
+		writeZshCompletion(a.stdout, binName)
 	case "fish":
-		writeFishCompletion(a.stdout, a.name)
+		writeFishCompletion(a.stdout, binName)
 	default:
 		fmt.Fprintf(
 			a.output,

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -173,7 +173,9 @@ func TestCompletionScripts(t *testing.T) {
 
 			output := buf.String()
 			require.NotEmpty(t, output)
-			assert.Contains(t, output, "testapp")
+			// The script should reference the actual binary name,
+			// not the app's logical name.
+			assert.NotContains(t, output, "testapp")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Completion scripts now use `os.Args[0]` (the actual binary name) instead of the app's logical name from `cli.New()`
- Fixes completions when the binary is renamed or symlinked (e.g. `rrcli` → `runreveal`)